### PR TITLE
feat!(ubuntu-build): replace apt-packages with generic env_setup_commonds

### DIFF
--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -16,8 +16,8 @@ on:
         type: string
         required: false
         default: jazzy
-      apt-packages:
-        description: 'List of apt packages to install, e.g. "python3-pip python3-rosdep"'
+      env_setup_commands:
+        description: 'Shell commands to run during environment setup (use "echo VAR=value >> $GITHUB_ENV" to set persistent variables)'
         type: string
         required: false
 
@@ -40,7 +40,11 @@ jobs:
           sudo add-apt-repository -y ppa:ubuntu-qcom-iot/qirp
 
           sudo apt update -y && sudo apt upgrade -y
-          sudo apt install -y ${{ inputs.apt-packages }} wget python3-bloom python3-rosdep fakeroot debhelper dh-python
+          sudo apt install -y wget python3-bloom python3-rosdep fakeroot debhelper dh-python
+
+          if [ -n "${{ inputs.env_setup_commands }}" ]; then
+            eval "${{ inputs.env_setup_commands }}"
+          fi
 
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ jobs:
     #   colcon_args:  --cmake-clean-first
     #   # ROS2 distribution to use, e.g. jazzy
     #   ros-distro: "jazzy"
-    #   # List of apt packages to install before colcon build
-    #   apt-packages: "libboost-all-dev"
+    #   # Shell commands to run during environment setup (use "echo VAR=value >> $GITHUB_ENV" to set persistent variables)
+    #   env_setup_commands: "sudo apt install libboost-all-dev"
 ```
 
 ## 🤝 Contributing


### PR DESCRIPTION
Replace apt-packages input with env_setup_commands to support arbitrary environment setup commands beyond just apt packages.

This change enables more versatile environment configuration while maintaining similar usage patterns for apt installations. Documentation now clearly explains how to set persistent variables using $GITHUB_ENV.

BREAKING CHANGE: The apt-packages parameter has been renamed and generalized to env_setup_commands. Users must update their workflows to use the new parameter and provide full shell commands instead of just package names.

Example migration:
  Before: apt-packages: "package1 package2"
  After:  env_setup_commands: |
            sudo apt-get update
            sudo apt-get install -y package1 package2