### PR TITLE
ci: remove artifacts upload in GCP and remove build and log dirs

### DIFF
--- a/.github/workflows/qirp-sdk-build-checker.yml
+++ b/.github/workflows/qirp-sdk-build-checker.yml
@@ -158,23 +158,16 @@ jobs:
             -DBUILD_TESTING=OFF
 
       - name: Stage build artifacts for publishing
-        continue-on-error: true
         run: |
           build_dir=./uploads
           mkdir -p $build_dir
 
-          tar -cvf ${build_dir}/${{ github.event.repository.name }}-${MACHINE}-${DISTRO}-${QCOM_SELECTED_BSP}-artifacts.tar --transform "s|^${WORKSPACE}/||" -C ${WORKSPACE} install build log
+          tar -cvf ${build_dir}/${{ github.event.repository.name }}-${MACHINE}-${DISTRO}-${QCOM_SELECTED_BSP}-artifacts.tar --transform "s|^${WORKSPACE}/||" -C ${WORKSPACE} install
 
       - name: Upload artifacts to S3 bucket
+        continue-on-error: true
         uses: qualcomm-linux/upload-private-artifact-action@aws-v2
         with:
           path: ./uploads
           destination: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.run_id }}-${{ github.run_attempt }}/
           s3_bucket: qli-prd-ros-gh-artifacts
-
-      - name: Upload private artifacts
-        continue-on-error: true
-        uses: qualcomm-linux/upload-private-artifact-action@v1
-        with:
-          path: ./uploads
-          fileserver_url: "https://quic-qrt-ros-fileserver-1029608027416.us-central1.run.app"

--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -98,12 +98,11 @@ jobs:
           done
 
       - name: Stage build artifacts for publishing
-        continue-on-error: true
         run: |
           build_dir=./uploads
           mkdir -p $build_dir
 
-          tar -cvf "${build_dir}/${{ github.event.repository.name }}-ubuntu-artifacts.tar" --transform "s|^${ROS_WS}/||" -C "${ROS_WS}" install build log
+          tar -cvf "${build_dir}/${{ github.event.repository.name }}-ubuntu-artifacts.tar" --transform "s|^${ROS_WS}/||" -C "${ROS_WS}" install
           tar -cvf "${build_dir}/${{ github.event.repository.name }}-ubuntu-debs.tar" --transform "s|^${ROS_WS}/||" -C "${ROS_WS}" debian_dir
 
       - name: Upload artifacts to S3 bucket
@@ -114,9 +113,3 @@ jobs:
           destination: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.run_id }}-${{ github.run_attempt }}/
           s3_bucket: qli-prd-ros-gh-artifacts
 
-      - name: Upload private artifacts
-        continue-on-error: true
-        uses: qualcomm-linux/upload-private-artifact-action@v1
-        with:
-          path: ./uploads
-          fileserver_url: "https://quic-qrt-ros-fileserver-1029608027416.us-central1.run.app"


### PR DESCRIPTION
1. Remove upload artifacts to GCP server.
2. Remove build and log directory from artifacts.