### PR TITLE
ci: use full repo ref for upload-artifact action in reusable workflows

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -11,14 +11,14 @@ permissions:
  security-events: write
 
 jobs:
-  qcom-preflight-checks:
-    uses: qualcomm/qcom-reusable-workflows/.github/workflows/qcom-preflight-checks-reusable-workflow.yml@v1.1.4
+  preflight:
+    name: Run QC Preflight Checks
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2
     with:
-        # ✅ Preflight Checkers
-        repolinter: true                   # default: true
-        semgrep: true                      # default: true
-        copyright-license-detector: true   # default: true
-        pr-check-emails: true              # default: true
-        dependency-review: true            # default: true
-    secrets:
-      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+      enable-semgrep-scan: true
+      enable-dependency-review: true
+      enable-repolinter-check: true
+      enable-copyright-license-check: true
+      enable-commit-email-check: true
+      enable-commit-msg-check: false
+      enable-armor-checkers: false

--- a/.github/workflows/qirp-sdk-build-checker.yml
+++ b/.github/workflows/qirp-sdk-build-checker.yml
@@ -167,9 +167,9 @@ jobs:
       - name: Upload artifacts to S3 bucket
         id: upload-artifacts
         continue-on-error: true
-        uses: ./.github/actions/upload-artifact
+        uses: qualcomm-qrb-ros/qrb_ros_gh_actions/.github/actions/upload-artifact@main
         with:
           path: ./uploads
           destination: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.run_id }}-${{ github.run_attempt }}/
           s3_bucket: qli-prd-ros-gh-artifacts
-          retention: 15d
+          retention: 7d

--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -108,10 +108,10 @@ jobs:
       - name: Upload artifacts to S3 bucket
         id: upload-artifacts
         continue-on-error: true
-        uses: ./.github/actions/upload-artifact
+        uses: qualcomm-qrb-ros/qrb_ros_gh_actions/.github/actions/upload-artifact@main
         with:
           path: ./uploads
           destination: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.run_id }}-${{ github.run_attempt }}/
           s3_bucket: qli-prd-ros-gh-artifacts
-          retention: 15d
+          retention: 7d
 


### PR DESCRIPTION
1. Local path `./.github/actions/upload-artifact` resolves relative to the caller's repo when used in a `workflow_call` reusable workflow, causing "Can't find action.yml" errors. Use the fully-qualified `qualcomm-qrb-ros/qrb_ros_gh_actions/...@main` reference instead.
2. upgrade qcom-preflight-checks to v2